### PR TITLE
[Feature Sniff, Don't Browser Sniff] Always put the W3C specification at the end

### DIFF
--- a/index.html
+++ b/index.html
@@ -708,7 +708,7 @@
 			
 			<script type="syntaxhighlighter" class="brush: js;  toolbar: false; gutter: false;"><![CDATA[
 				if ($.browser.msie) {
-					// no it doesn’t
+					// no it doesnï¿½t
 				}				
 			]]></script>
 			
@@ -1112,9 +1112,9 @@
 				
 				.borderimage .my_elem {
 				   border: none;
-				   border-image: url(fancy-border.png) 5 5 5 5 round;
-				   -moz-border-image: url(fancy-border.png) 5 5 5 5 round;
 				   -webkit-border-image: url(fancy-border.png) 5 5 5 5 round;
+				   -moz-border-image: url(fancy-border.png) 5 5 5 5 round;
+				   border-image: url(fancy-border.png) 5 5 5 5 round;
 				}
 			]]></script>
 			


### PR DESCRIPTION
Optional, I always put the longest one first (webkit > moz > ms > o).
